### PR TITLE
fix for using with FastCGI servers

### DIFF
--- a/wiki.pl
+++ b/wiki.pl
@@ -424,7 +424,7 @@ sub InitRequest {
   } else {
     $CGI::DISABLE_UPLOADS = 1;  # no uploads
   }
-  $q = new CGI;
+  $q ||= new CGI;
   # Fix some issues with editing UTF8 pages (if charset specified)
   if ($HttpCharset ne '') {
     $q->charset($HttpCharset);


### PR DESCRIPTION
This fix enable the UseModWiki working with FastCGI servers.
Without this fix, the wiki has trouble in POST method requests for page edits.
I refered the corresponding line of the Oddmuse code.
